### PR TITLE
refactor: move consumer config to cronsumer struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ func main() {
     }
     
     cronsumer := kcronsumer.NewCronsumer(kafkaConfig, consumeFn)
-    cronsumer.Run(kafkaConfig.Consumer)
+    cronsumer.Run()
 }
 ```
 
@@ -62,7 +62,7 @@ func main() {
     }
     
     cronsumer := kcronsumer.NewCronsumer(kafkaConfig, consumeFn)
-    cronsumer.Run(kafkaConfig.Consumer)
+    cronsumer.Run()
 }
 ```
 
@@ -76,14 +76,14 @@ func main() {
         return nil
     }
     firstHandler := kcronsumer.NewCronsumer(firstCfg, firstConsumerFn)
-    firstHandler.Start(firstCfg.Consumer)
+    firstHandler.Start()
     
     var secondConsumerFn kcronsumer.ConsumeFn = func(message model.Message) error {
         fmt.Printf("Second consumer > Message received: %s\n", string(message.Value))
         return nil
     }
     secondHandler := kcronsumer.NewCronsumer(secondCfg, secondConsumerFn)
-    secondHandler.Start(firstCfg.Consumer)
+    secondHandler.Start()
     // ...    
 }
 ```

--- a/cronsumer.go
+++ b/cronsumer.go
@@ -11,8 +11,8 @@ import (
 type ConsumeFn func(message model.Message) error
 
 type Cronsumer interface {
-	Start(cfg model.ConsumerConfig)
-	Run(cfg model.ConsumerConfig)
+	Start()
+	Run()
 	Stop()
 }
 

--- a/example/multiple-consumers/main.go
+++ b/example/multiple-consumers/main.go
@@ -18,14 +18,14 @@ func main() {
 		return nil
 	}
 	firstHandler := kcronsumer.NewCronsumer(firstCfg, firstConsumerFn)
-	firstHandler.Start(firstCfg.Consumer)
+	firstHandler.Start()
 
 	var secondConsumerFn kcronsumer.ConsumeFn = func(message model.Message) error {
 		fmt.Printf("Second consumer > Message received: %s\n", string(message.Value))
 		return nil
 	}
 	secondHandler := kcronsumer.NewCronsumer(secondCfg, secondConsumerFn)
-	secondHandler.Start(firstCfg.Consumer)
+	secondHandler.Start()
 
 	select {} // block main goroutine (we did to show it by on purpose)
 }

--- a/example/single-consumer-with-deadletter/main.go
+++ b/example/single-consumer-with-deadletter/main.go
@@ -19,7 +19,7 @@ func main() {
 	}
 
 	cronsumer := kcronsumer.NewCronsumer(kafkaConfig, consumeFn)
-	cronsumer.Run(kafkaConfig.Consumer)
+	cronsumer.Run()
 }
 
 func getConfig() *model.KafkaConfig {

--- a/example/single-consumer/main.go
+++ b/example/single-consumer/main.go
@@ -18,7 +18,7 @@ func main() {
 	}
 
 	cronsumer := kcronsumer.NewCronsumer(kafkaConfig, consumeFn)
-	cronsumer.Run(kafkaConfig.Consumer)
+	cronsumer.Run()
 }
 
 func getConfig() *model.KafkaConfig {

--- a/internal/cronsumer.go
+++ b/internal/cronsumer.go
@@ -8,12 +8,13 @@ import (
 )
 
 type Cronsumer interface {
-	Start(cfg model.ConsumerConfig)
-	Run(cfg model.ConsumerConfig)
+	Start()
+	Run()
 	Stop()
 }
 
 type cronsumer struct {
+	cfg      *model.KafkaConfig
 	cron     *gocron.Cron
 	consumer KafkaCronsumer
 	logger   model.Logger
@@ -30,6 +31,7 @@ func NewCronsumer(cfg *model.KafkaConfig, c func(message model.Message) error) C
 		cron:     gocron.New(),
 		consumer: consumer,
 		logger:   l,
+		cfg:      cfg,
 	}
 }
 
@@ -40,11 +42,13 @@ func NewCronsumerWithLogger(cfg *model.KafkaConfig, c func(m model.Message) erro
 		cron:     gocron.New(),
 		consumer: consumer,
 		logger:   l,
+		cfg:      cfg,
 	}
 }
 
 // Start starts the kafka consumer KafkaCronsumer with a new goroutine so its asynchronous operation (non-blocking)
-func (s *cronsumer) Start(cfg model.ConsumerConfig) {
+func (s *cronsumer) Start() {
+	cfg := s.cfg.Consumer
 	checkRequiredParams(cfg)
 	_, _ = s.cron.AddFunc(cfg.Cron, func() {
 		s.logger.Info("Topic started at time: " + time.Now().String())
@@ -55,7 +59,8 @@ func (s *cronsumer) Start(cfg model.ConsumerConfig) {
 }
 
 // Run runs the kafka consumer KafkaCronsumer with the caller goroutine so its synchronous operation (blocking)
-func (s *cronsumer) Run(cfg model.ConsumerConfig) {
+func (s *cronsumer) Run() {
+	cfg := s.cfg.Consumer
 	checkRequiredParams(cfg)
 	_, _ = s.cron.AddFunc(cfg.Cron, func() {
 		s.logger.Info("Topic started at time: " + time.Now().String())


### PR DESCRIPTION
It's more efficient to manage logger from config with a pointer such as [gorm](https://github.com/go-gorm/gorm/blob/0b7113b618584edd76d74e7a73eecc2a28a4d17a/gorm.go#L29).