### PR TITLE
Update debezium/zookeeper image version

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   zookeeper:
-    image: debezium/zookeeper
+    image: debezium/zookeeper:2.6
     ports:
       - "2181:2181"
 


### PR DESCRIPTION
When I run docker-compose file which is located at examples. I face with `zookeeper Error    manifest for debezium/zookeeper:latest not found: manifest unknown: manifest unknown  ` error, for solving this problem I updated image version of debezium/zookeeper.