### PR TITLE
ci: add security scanning workflow (govulncheck, Trivy, SBOM)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,90 @@
+name: 🔒 Security
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+  schedule:
+    # Run weekly on Monday 08:00 UTC to catch newly published CVEs
+    - cron: '0 8 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  govulncheck:
+    name: Go Vulnerability Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+
+  trivy-fs:
+    name: Trivy Filesystem Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Trivy (filesystem)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          trivy-config: .trivy.yaml
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+
+      - name: Upload Trivy SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate SBOM with Trivy
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json
+          retention-days: 90

--- a/.trivy.yaml
+++ b/.trivy.yaml
@@ -1,0 +1,10 @@
+scan:
+  skip-dirs:
+    - vendor
+    - testdata
+
+vulnerability:
+  ignore-unfixed: false
+
+misconfiguration:
+  include-non-failures: false


### PR DESCRIPTION
## What

This PR introduces a dedicated `security.yml` GitHub Actions workflow that adds three security gates currently missing from the CI pipeline.

## Why

Without automated vulnerability scanning, CVEs in dependencies can silently reach production. The Go ecosystem has an official vulnerability database (`govulncheck`) and filesystem scanning via Trivy is widely adopted industry standard.

## Changes

**`.github/workflows/security.yml`** — three parallel jobs:

| Job | Tool | Purpose |
|---|---|---|
| `govulncheck` | `golang.org/x/vuln` | Detect known CVEs in Go module dependencies via the Go vuln DB |
| `trivy-fs` | Trivy 0.28 | Filesystem scan for HIGH/CRITICAL CVEs; results uploaded as SARIF to the GitHub Security tab |
| `sbom` | Trivy (CycloneDX) | Generate a Software Bill of Materials artifact retained for 90 days |

**`.trivy.yaml`** — Trivy config that skips `vendor/` and `testdata/` to reduce noise.

**Trigger schedule:** runs on every push/PR to `main` and weekly (Monday 08:00 UTC) so newly published CVEs are caught between releases.

## Test plan

- [ ] Workflow syntax validated with `actionlint`
- [ ] `govulncheck ./...` passes on current codebase
- [ ] Trivy scan completes without blocking HIGH/CRITICAL findings
- [ ] SBOM artifact is generated and downloadable from the Actions run